### PR TITLE
ArmPlatformPkg: Bds: initialize console earlier

### DIFF
--- a/ArmPlatformPkg/Bds/Bds.c
+++ b/ArmPlatformPkg/Bds/Bds.c
@@ -479,6 +479,9 @@ BdsEntry (
   Status = gBS->CalculateCrc32 ((VOID*)gST, gST->Hdr.HeaderSize, &gST->Hdr.CRC32);
   ASSERT_EFI_ERROR (Status);
 
+  // Now we need to setup the EFI System Table with information about the console devices.
+  InitializeConsole ();
+
   // If BootNext environment variable is defined then we just load it !
   BootNextSize = sizeof(UINT16);
   Status = GetGlobalEnvironmentVariable (L"BootNext", NULL, &BootNextSize, (VOID**)&BootNext);
@@ -517,9 +520,6 @@ BdsEntry (
 
   // If Boot Order does not exist then create a default entry
   DefineDefaultBootEntries ();
-
-  // Now we need to setup the EFI System Table with information about the console devices.
-  InitializeConsole ();
 
   //
   // Update the CRC32 in the EFI System Table header


### PR DESCRIPTION
If console is initialized earlier, we could avoid the error that is reported in
the commit below.

  commit b1ea43a4adf29114215e71227584c23cef007393
  Author: Haojian Zhuang haojian.zhuang@linaro.org
  Date:   Mon Jun 15 10:31:50 2015 +0800

```
  HiKey: bootmenu: create a boot menu for debian

  Here's a limitation that disable BootOptionStart() in ArmPlatformPkg/Bds/BdsHelper.c.
  It seems that there's a bug in BootOptionStart().

  Otherwise, an error occurs.

  Loading driver at 0x000372EC000 EntryPoint=0x00037D629C0
  Loading driver at 0x000372EC000 EntryPoint=0x00037D629C0
  Synchronous Exception at 0x0000000000000000
```

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
