### PR TITLE
MdeModulePkg: TerminalDxe: select the UART's default receive FIFO depth

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.c
@@ -806,7 +806,7 @@ TerminalDriverBindingStart (
     Status = TerminalDevice->SerialIo->SetAttributes (
                                         TerminalDevice->SerialIo,
                                         Mode->BaudRate,
-                                        Mode->ReceiveFifoDepth,
+                                        0, // the device's default FIFO depth
                                         (UINT32) SerialInTimeOut,
                                         (EFI_PARITY_TYPE) (Mode->Parity),
                                         (UINT8) Mode->DataBits,

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -547,7 +547,7 @@ TerminalConInTimerHandler (
     Status = SerialIo->SetAttributes (
                         SerialIo,
                         Mode->BaudRate,
-                        Mode->ReceiveFifoDepth,
+                        0, // the device's default FIFO depth
                         (UINT32) SerialInTimeOut,
                         (EFI_PARITY_TYPE) (Mode->Parity),
                         (UINT8) Mode->DataBits,


### PR DESCRIPTION
The Serial IO protocol instances provided by SerialDxe and consumed by
TerminalDxe come with a Mode.ReceiveFifoDepth=1 default setting, as
required by UEFI 2.5.

Although TerminalDxe calls EFI_SERIAL_IO_PROTOCOL.SetAttributes() in the
TerminalDriverBindingStart() and TerminalConInTimerHandler() functions, it
only does so to change the Mode.Timeout member. Other members of Mode,
including Mode.ReceiveFifoDepth, are preserved.

On some platforms this causes the UART that underlies TerminalDxe not to
have enough room for bursts of scan codes, which translates to broken
parsing of escape sequences, e.g. cursor movement keys.

According to the UEFI spec, passing ReceiveFifoDepth=0 to
EFI_SERIAL_IO_PROTOCOL.SetAttributes() "will use the device's default FIFO
depth". While TerminalDxe could try to configure a receive FIFO depth that
matches the longest escape sequence it wishes to parse, in practice the
device-specific default FIFO depth -- which may well differ from the
spec-mandated SerialIo->Mode.ReceiveFifoDepth=1 default -- seems to work.
Hence let's just set that.

This issue was exposed by SVN r18971 / git commit 921e987b2b
("ArmPlatformPkg: Use SerialDxe in MdeModulePkg instead of EmbeddedPkg").
In that conversion, MdeModulePkg's SerialDxe started to initialize
Mode.ReceiveFifoDepth to 1 (in conformance with the spec), unlike the
prior, non-conformant initialization to 0 in EmbeddedPkg's SerialDxe.

Since TerminalDxe would never change ReceiveFifoDepth from the new default
value 1, and the ArmPlatformPkg/Drivers/PL011Uart library instance,
underlying SerialDxe through SerialPortLib, would obey it too, they would
collectively effect a receive queue depth of 1, rather than the default 16
or 32. This broke cursor keys on the ARM FVP and Juno platforms.

It is the client of EFI_SERIAL_IO_PROTOCOL that is responsible for
modifying the attributes, if the defaults are not appropriate, hence this
patch modifies TerminalDxe.

Cc: Ard Biesheuvel ard.biesheuvel@linaro.org
Cc: Ryan Harkin ryan.harkin@linaro.org
Cc: Leif Lindholm leif.lindholm@linaro.org
Cc: Star Zeng star.zeng@intel.com
Reported-by: Ryan Harkin ryan.harkin@linaro.org
Reference: http://thread.gmane.org/gmane.comp.bios.edk2.devel/4779/focus=6553
Reference: http://thread.gmane.org/gmane.comp.bios.edk2.devel/6594
Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Laszlo Ersek lersek@redhat.com
Tested-by: Ard Biesheuvel ard.biesheuvel@linaro.org
Reviewed-by: Ard Biesheuvel ard.biesheuvel@linaro.org
Tested-by: Ryan Harkin ryan.harkin@linaro.org
Reviewed-by: Star Zeng star.zeng@intel.com

git-svn-id: https://svn.code.sf.net/p/edk2/code/trunk/edk2@19701 6f19259b-4bc3-4df7-8a09-765794883524
