### PR TITLE
debug: fix to init BdsLoadOption

### DIFF
--- a/ArmPkg/Library/BdsLib/BdsFilePath.c
+++ b/ArmPkg/Library/BdsLib/BdsFilePath.c
@@ -1515,7 +1515,7 @@ BdsAndroidKernelLoadImage (
   UINT32                        MediaId;
   UINTN                         BlockSize;
   VOID                         *Buffer;
-  BDS_LOAD_OPTION              *BdsLoadOption;
+  BDS_LOAD_OPTION              *BdsLoadOption = NULL;
 
   /* Find DevicePath node of Partition */
   NextNode = *DevicePath;


### PR DESCRIPTION
It's used to fix build error for release build.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
