### PR TITLE
PL061: fix the offset in gpio input

### DIFF
--- a/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.c
+++ b/ArmPlatformPkg/Drivers/PL061GpioDxe/PL061Gpio.c
@@ -227,7 +227,7 @@ Set (
   {
     case GPIO_MODE_INPUT:
       // Set the corresponding direction bit to LOW for input
-      MmioAnd8 (RegisterBase + PL061_GPIO_DIR_REG, ~GPIO_PIN_MASK(Gpio));
+      MmioAnd8 (RegisterBase + PL061_GPIO_DIR_REG, ~GPIO_PIN_MASK(Offset));
       break;
 
     case GPIO_MODE_OUTPUT_0:


### PR DESCRIPTION
The offset calculation should be based on the pin offset in PL061
controller, not gpio index in the platform.

Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
