### PR TITLE
BdsFilePath: update ramdiskbase

### DIFF
--- a/ArmPkg/Library/BdsLib/BdsFilePath.c
+++ b/ArmPkg/Library/BdsLib/BdsFilePath.c
@@ -1397,6 +1397,8 @@ STATIC LoadAndroidBootImg (
              (VOID *)((UINTN)Buffer + Header->PageSize + ALIGN_VALUE (Header->KernelSize, Header->PageSize)),
 	     Header->RamdiskSize
 	    );
+    if (RamdiskBase != Header->RamdiskAddress)
+      Header->RamdiskAddress = RamdiskBase;
   }
   /* Install Fdt */
   KernelSize = *(UINT32 *)(KernelBase + KERNEL_IMAGE_STEXT_OFFSET) +


### PR DESCRIPTION
Since ramdisk is stored at the allocated address now, change the ramdisk
base in the header of android boot image.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
