### PR TITLE
BdsLib: hack to load hikey serialno for aosp boot

### DIFF
--- a/ArmPkg/Library/BdsLib/BdsLib.inf
+++ b/ArmPkg/Library/BdsLib/BdsLib.inf
@@ -32,6 +32,7 @@
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   ArmPlatformPkg/ArmPlatformPkg.dec
+  OpenPlatformPkg/Platforms/Hisilicon/HiKey/HiKey.dec
 
 [LibraryClasses]
   ArmLib
@@ -45,6 +46,7 @@
 [Guids]
   gEfiFileInfoGuid
   gFdtTableGuid
+  gHiKeyVariableGuid
 
 [Protocols]
   gEfiBdsArchProtocolGuid


### PR DESCRIPTION
Load HiKey SerialNo from HiKey platform. And pass it to kernel args.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
