### PR TITLE
Remove redundand ReadBlock call

### DIFF
--- a/EmbeddedPkg/Universal/MmcDxe/MmcIdentification.c
+++ b/EmbeddedPkg/Universal/MmcDxe/MmcIdentification.c
@@ -428,12 +428,6 @@ InitializeSdMmcDevice (
     if (EFI_ERROR (Status)) {
       DEBUG ((EFI_D_ERROR, "%a(MMC_CMD6): Error and Status = %r\n", Status));
        return Status;
-    } else {
-      Status = MmcHost->ReadBlockData (MmcHost, 0, 64, Buffer);
-      if (EFI_ERROR (Status)) {
-        DEBUG ((EFI_D_ERROR, "%a(MMC_CMD6): ReadBlockData Error and Status = %r\n", Status));
-        return Status;
-      }
     }
   }
   if (Scr.SD_BUS_WIDTHS & SD_BUS_WIDTH_4BIT) {


### PR DESCRIPTION
The subsequent call fails with device error during
intialization after ReadBlockData call following CMD6.
I am guessing it has to do with some DMA state since if
we add a debug print between this call and next sendCommand
would result in proper functioning of the device.

Change-Id: Ib5b027237bdf9360348c031d605af5eac47de842
Signed-off-by: Vishal Bhoj <vishal.bhoj@linaro.org>