### PR TITLE
BaseTools/VfrCompile: Remove the MAX_PATH limitation

### DIFF
--- a/BaseTools/Source/C/VfrCompile/EfiVfr.h
+++ b/BaseTools/Source/C/VfrCompile/EfiVfr.h
@@ -1,7 +1,7 @@
 /** @file
 Defines and prototypes for the UEFI VFR compiler internal use.
 
-Copyright (c) 2004 - 2014, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2004 - 2017, Intel Corporation. All rights reserved.<BR>
 This program and the accompanying materials                          
 are licensed and made available under the terms and conditions of the BSD License         
 which accompanies this distribution.  The full text of the license may be found at        
@@ -19,7 +19,6 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include "Common/UefiInternalFormRepresentation.h"
 #include "Common/MdeModuleHii.h"
 
-#define MAX_PATH                 255
 #define MAX_VFR_LINE_LEN         4096
 
 #define EFI_IFR_MAX_LENGTH       0xFF

--- a/BaseTools/Source/C/VfrCompile/VfrCompiler.cpp
+++ b/BaseTools/Source/C/VfrCompile/VfrCompiler.cpp
@@ -119,10 +119,6 @@ CVfrCompiler::OptionInitialization (
         DebugError (NULL, 0, 1001, "Missing option", "-o missing output directory name");
         goto Fail;
       }
-      if (strlen (Argv[Index]) > MAX_PATH - 1) {
-        DebugError (NULL, 0, 1003, "Invalid option value", "Output directory name %s is too long", Argv[Index]);
-        goto Fail;
-      }
 
       mOptions.OutputDirectory = (CHAR8 *) malloc (strlen (Argv[Index]) + strlen ("\\") + 1);
       if (mOptions.OutputDirectory == NULL) {
@@ -186,10 +182,6 @@ CVfrCompiler::OptionInitialization (
     DebugError (NULL, 0, 1001, "Missing option", "VFR file name is not specified.");
     goto Fail;
   } else {
-    if (strlen (Argv[Index]) > MAX_PATH) {
-      DebugError (NULL, 0, 1003, "Invalid option value", "VFR file name %s is too long.", Argv[Index]);
-      goto Fail;
-    }
     mOptions.VfrFileName = (CHAR8 *) malloc (strlen (Argv[Index]) + 1);
     if (mOptions.VfrFileName == NULL) {
       DebugError (NULL, 0, 4001, "Resource: memory can't be allocated", NULL);
@@ -355,10 +347,6 @@ CVfrCompiler::SetBaseFileName (
   }
 
   *pExt = '\0';
-  if (strlen (pFileName) > MAX_PATH - 1) {
-    *pExt = '.';
-    return -1;
-  }
 
   mOptions.VfrBaseFileName = (CHAR8 *) malloc (strlen (pFileName) + 1);
   if (mOptions.VfrBaseFileName == NULL) {
@@ -387,9 +375,6 @@ CVfrCompiler::SetPkgOutputFileName (
            strlen (mOptions.VfrBaseFileName) +
            strlen (VFR_PACKAGE_FILENAME_EXTENSION) +
            1;
-  if (Length > MAX_PATH) {
-    return -1;
-  }
 
   mOptions.PkgOutputFileName = (CHAR8 *) malloc (Length);
   if (mOptions.PkgOutputFileName == NULL) {
@@ -418,9 +403,6 @@ CVfrCompiler::SetCOutputFileName (
            strlen (mOptions.VfrBaseFileName) +
            strlen (".c") +
            1;
-  if (Length > MAX_PATH) {
-    return -1;
-  }
 
   mOptions.COutputFileName = (CHAR8 *) malloc (Length);
   if (mOptions.COutputFileName == NULL) {
@@ -449,9 +431,6 @@ CVfrCompiler::SetPreprocessorOutputFileName (
            strlen (mOptions.VfrBaseFileName) +
            strlen (VFR_PREPROCESS_FILENAME_EXTENSION) +
            1;
-  if (Length > MAX_PATH) {
-    return -1;
-  }
 
   mOptions.PreprocessorOutputFileName = (CHAR8 *) malloc (Length);
   if (mOptions.PreprocessorOutputFileName == NULL) {
@@ -480,9 +459,6 @@ CVfrCompiler::SetRecordListFileName (
            strlen (mOptions.VfrBaseFileName) +
            strlen (VFR_RECORDLIST_FILENAME_EXTENSION) +
            1;
-  if (Length > MAX_PATH) {
-    return -1;
-  }
 
   mOptions.RecordListFile = (CHAR8 *) malloc (Length);
   if (mOptions.RecordListFile == NULL) {


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=579

Since we have already used LongFilePath() to convert
file path, so we can remove the MAX_PATH limitation.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Daniel Díaz <daniel.diaz@linaro.org>
Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Dandan Bi <dandan.bi@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>