### PR TITLE
EmbeddedPkg/AndroidFastboot: support raw kernel image

### DIFF
--- a/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf
+++ b/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf
@@ -43,6 +43,7 @@
 [Protocols]
   gAndroidFastbootTransportProtocolGuid
   gAndroidFastbootPlatformProtocolGuid
+  gEfiBlockIoProtocolGuid
   gEfiSimpleTextOutProtocolGuid
   gEfiSimpleTextInProtocolGuid
 
@@ -57,3 +58,6 @@
 
 [Guids]
   gFdtTableGuid
+
+[Pcd]
+  gEmbeddedTokenSpaceGuid.PcdAndroidBootDevicePath

--- a/EmbeddedPkg/Include/Library/AbootimgLib.h
+++ b/EmbeddedPkg/Include/Library/AbootimgLib.h
@@ -62,4 +62,12 @@ AbootimgBoot (
   IN UINTN                   BufferSize
   );
 
+EFI_STATUS
+AbootimgBootKernel (
+  IN VOID                            *Buffer,
+  IN UINTN                            BufferSize,
+  IN VOID                            *ImgBuffer,
+  IN UINTN                            ImgBufferSize
+  );
+
 #endif /* __ABOOTIMG_H__ */


### PR DESCRIPTION
AndroidFastbootApp could boot raw image with ramdisk & args in existed
boot image on storage device.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>