### PR TITLE
VfrCompile: fix invalid comparison between pointer and integer

### DIFF
--- a/BaseTools/Source/C/VfrCompile/VfrUtilityLib.cpp
+++ b/BaseTools/Source/C/VfrCompile/VfrUtilityLib.cpp
@@ -3372,7 +3372,7 @@ CVfrStringDB::GetVarStoreNameFormStringId (
   UINT8       BlockType;
   EFI_HII_STRING_PACKAGE_HDR *PkgHeader;
   
-  if (mStringFileName == '\0' ) {
+  if (mStringFileName == NULL) {
     return NULL;
   }
 


### PR DESCRIPTION
This would be valid C but is not valid C++, so change the comparison to do what it has always been doing.

Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
Reviewed-by: Yonghong Zhu <yonghong.zhu@intel.com>