### PR TITLE
MdeModulePkg/UefiHiiLib:Fix incorrect comparison expression

### DIFF
--- a/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
+++ b/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
@@ -2180,8 +2180,9 @@ InternalHiiIfrValueAction (
   }
   
   StringPtr = ConfigAltResp;
-  
-  while (StringPtr != L'\0') {
+  ASSERT (StringPtr != NULL);
+
+  while (*StringPtr != L'\0') {
     //
     // 1. Find <ConfigHdr> GUID=...&NAME=...&PATH=...
     //


### PR DESCRIPTION
Fix the incorrect comparison between pointer and constant zero character.

https://bugzilla.tianocore.org/show_bug.cgi?id=416

V2: The pointer StringPtr points to a string returned
by ExtractConfig/ExportConfig, if it is NULL, function
InternalHiiIfrValueAction will return FALSE. So in
current usage model, the StringPtr can not be NULL before
using it, so we can add ASSERT here.

Cc: Eric Dong <eric.dong@intel.com>
Cc: Liming Gao <liming.gao@intel.com>
Contributed-under: TianoCore Contribution Agreement 1.0
Signed-off-by: Dandan Bi <dandan.bi@intel.com>
Reviewed-by: Eric Dong <eric.dong@intel.com>