### PR TITLE
EmbeddedPkg/AbootimgLib: fix build error for uninitialized

### DIFF
--- a/EmbeddedPkg/Library/AbootimgLib/AbootimgLib.c
+++ b/EmbeddedPkg/Library/AbootimgLib/AbootimgLib.c
@@ -378,7 +378,7 @@ LoadBootImage (
 {
   EFI_STATUS                 Status;
   EFI_BLOCK_IO_PROTOCOL      *BlockIo;
-  UINTN                      BootImageSize;
+  UINTN                      BootImageSize = 0;
 
   if ((Buffer == NULL) || (BufferSize == NULL)) {
     return EFI_INVALID_PARAMETER;


### PR DESCRIPTION
staging/41/edk2/EmbeddedPkg/Library/AbootimgLib/AbootimgLib.c: In function ‘LoadBootImage.part.3’:
/home/buildslave/workspace/96boards-reference-uefi-staging/41/edk2/EmbeddedPkg/Library/AbootimgLib/AbootimgLib.c:414:36: error: ‘BootImageSize’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   BootImageSize = ALIGN_VALUE (BootImageSize, BlockIo->Media->BlockSize);
                   ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>