### PR TITLE
Zlib.inf: Add StdLib to Packages to allow building with android

### DIFF
--- a/EmbeddedPkg/Library/ZLib/ZLib.inf
+++ b/EmbeddedPkg/Library/ZLib/ZLib.inf
@@ -41,6 +41,7 @@
   ZLib.c
 
 [Packages]
+  StdLib/StdLib.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec


### PR DESCRIPTION
The android toolchain can't find <sys/types.h> referenced in
Zlib code, so specify the StdLib package so we pull in the
UEFI library headers.

Change-Id: I1ac2c7e50a224495818e05aac0e166931ab33eea
Signed-off-by: John Stultz <john.stultz@linaro.org>