### PR TITLE
EmbeddedPkg/AndroidFastboot: add delay before reboot

### DIFF
--- a/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
+++ b/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
@@ -21,6 +21,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
+#include <Library/TimerLib.h>
 #include <Library/UefiApplicationEntryPoint.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
@@ -439,6 +440,7 @@ AcceptCmd (
       }
     }
     SEND_LITERAL ("OKAY");
+    MicroSecondDelay (3000000);
     gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
 
     // Shouldn't get here

--- a/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf
+++ b/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf
@@ -35,6 +35,7 @@
   MemoryAllocationLib
   PcdLib
   PrintLib
+  TimerLib
   UefiApplicationEntryPoint
   UefiBootServicesTableLib
   UefiLib


### PR DESCRIPTION
Add delay since some data may not be synced into storage device.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>