### PR TITLE
Revert "EmbeddedPkg/AndroidFastboot: add delay before reboot"

### DIFF
--- a/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
+++ b/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
@@ -21,7 +21,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
-#include <Library/TimerLib.h>
 #include <Library/UefiApplicationEntryPoint.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
@@ -440,7 +439,6 @@ AcceptCmd (
       }
     }
     SEND_LITERAL ("OKAY");
-    MicroSecondDelay (3000000);
     gRT->ResetSystem (EfiResetCold, EFI_SUCCESS, 0, NULL);
 
     // Shouldn't get here

--- a/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf
+++ b/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.inf
@@ -35,7 +35,6 @@
   MemoryAllocationLib
   PcdLib
   PrintLib
-  TimerLib
   UefiApplicationEntryPoint
   UefiBootServicesTableLib
   UefiLib


### PR DESCRIPTION
This reverts commit af60f944df3f405235f1bcdc8a6682628429c753.

Since the similar function is merged into ARM Trusted Firmware,
we don't need to implement it in edk2 common code any more.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>