### PR TITLE
MdeModulePkg/UfsPassThruDxe: avoid ufs hang by adding delay

### DIFF
--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
@@ -1195,6 +1195,7 @@ UfsRwFlags (
   ASSERT (QueryResp != NULL);
   CmdDescSize = Trd->RuO * sizeof (UINT32) + Trd->RuL * sizeof (UINT32);
 
+  MicroSecondDelay (100000);
   //
   // Start to execute the transfer request.
   //
@@ -1362,6 +1363,7 @@ UfsExecNopCmds (
   ASSERT (NopInUpiu != NULL);
   CmdDescSize = Trd->RuO * sizeof (UINT32) + Trd->RuL * sizeof (UINT32);
 
+  MicroSecondDelay (100000);
   //
   // Start to execute the transfer request.
   //


### PR DESCRIPTION
When UEFI is built in release mode, it's always hang on HiKey960
platform without this patch.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>