### PR TITLE
BaseTools/tools_def: add "-fno-unwind-tables" to GCC_AARCH64_CC_FLAGS (GCC 8.1)

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -4344,7 +4344,7 @@ DEFINE GCC_X64_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mno-red-zone -Wno-ad
 DEFINE GCC_IPF_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -minline-int-divide-min-latency
 DEFINE GCC_ARM_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mlittle-endian -mabi=aapcs -fno-short-enums -funsigned-char -ffunction-sections -fdata-sections -fomit-frame-pointer -fno-builtin -Wno-address -mthumb -mfloat-abi=soft
 DEFINE GCC_ARM_CC_XIPFLAGS         = -mno-unaligned-access
-DEFINE GCC_AARCH64_CC_FLAGS        = DEF(GCC_ALL_CC_FLAGS) -mlittle-endian -fno-short-enums -fverbose-asm -funsigned-char  -ffunction-sections -fdata-sections -fno-builtin -Wno-address -fno-asynchronous-unwind-tables  -fno-pic -fno-pie -ffixed-x18
+DEFINE GCC_AARCH64_CC_FLAGS        = DEF(GCC_ALL_CC_FLAGS) -mlittle-endian -fno-short-enums -fverbose-asm -funsigned-char  -ffunction-sections -fdata-sections -fno-builtin -Wno-address -fno-asynchronous-unwind-tables -fno-unwind-tables -fno-pic -fno-pie -ffixed-x18
 DEFINE GCC_AARCH64_CC_XIPFLAGS     = -mstrict-align
 DEFINE GCC_DLINK_FLAGS_COMMON      = -nostdlib --pie
 DEFINE GCC_DLINK2_FLAGS_COMMON     = -Wl,--script=$(EDK_TOOLS_PATH)/Scripts/GccBase.lds


### PR DESCRIPTION
The ElfConvert routines in GenFw don't handle the ".eh_frame" ELF section
emitted by gcc. For this reason, Leif disabled the generation of that
section for AARCH64 with "-fno-asynchronous-unwind-tables" in commit
28e80befa4fe [1], and Ard did the same for IA32 and X64 in commit
26ecc55c027d [2]. (The CLANG38 toolchain received the same flag at its
inception, in commit 6f756db5ea05 [3].)

However, ".eh_frame" is back now; in upstream gcc commit 9cbee213b579 [4]
(part of tag "gcc-8_1_0-release"), both "-fasynchronous-unwind-tables" and
"-funwind-tables" were made the default for AARCH64. (The patch author
described the effects on the gcc mailing list [5].) We have to counter the
latter flag with "-fno-unwind-tables", otherwise GenFw chokes on
".eh_frame" again (triggered for example on Fedora 28).

"-f[no-]unwind-tables" goes back to at least gcc-4.4 [6], so it's safe to
add to GCC_AARCH64_CC_FLAGS.

[1] https://github.com/tianocore/edk2/commit/28e80befa4fe
[2] https://github.com/tianocore/edk2/commit/26ecc55c027d
[3] https://github.com/tianocore/edk2/commit/6f756db5ea05
[4] https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=9cbee213b579
[5] http://mid.mail-archive.com/7b28c03a-c032-6cec-c127-1c12cbe98eeb@foss.arm.com
[6] https://gcc.gnu.org/onlinedocs/gcc-4.4.7/gcc/Code-Gen-Options.html

Cc: "Danilo C. L. de Paula" <ddepaula@redhat.com>
Cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>
Cc: Cole Robinson <crobinso@redhat.com>
Cc: Gerd Hoffmann <kraxel@redhat.com>
Cc: Leif Lindholm <leif.lindholm@linaro.org>
Cc: Liming Gao <liming.gao@intel.com>
Cc: Paolo Bonzini <pbonzini@redhat.com>
Cc: Yonghong Zhu <yonghong.zhu@intel.com>
Reported-by: "Danilo C. L. de Paula" <ddepaula@redhat.com>
Contributed-under: TianoCore Contribution Agreement 1.1
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
Reviewed-by: Ard Biesheuvel <ard.biesheuvel@linaro.org>
Reviewed-by: Liming Gao <liming.gao@intel.com>