### PR TITLE
EmbeddedPkg/AndroidFastboot: Fix overflow in Offset calculations

### DIFF
--- a/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
+++ b/EmbeddedPkg/Application/AndroidFastboot/AndroidFastbootApp.c
@@ -227,11 +227,11 @@ FlashSparseImage (
       if (EFI_ERROR (Status)) {
         return Status;
       }
-      Image += ChunkHeader->ChunkSize * SparseHeader->BlockSize;
-      Offset += ChunkHeader->ChunkSize * SparseHeader->BlockSize;
+      Image += (UINTN)ChunkHeader->ChunkSize * SparseHeader->BlockSize;
+      Offset += (UINTN)ChunkHeader->ChunkSize * SparseHeader->BlockSize;
       break;
     case CHUNK_TYPE_FILL:
-      Left = ChunkHeader->ChunkSize * SparseHeader->BlockSize;
+      Left = (UINTN)ChunkHeader->ChunkSize * SparseHeader->BlockSize;
       while (Left > 0) {
         if (Left > FILL_BUF_SIZE) {
           Count = FILL_BUF_SIZE;
@@ -254,7 +254,7 @@ FlashSparseImage (
       Image += sizeof (UINT32);
       break;
     case CHUNK_TYPE_DONT_CARE:
-      Offset += ChunkHeader->ChunkSize * SparseHeader->BlockSize;
+      Offset += (UINTN)ChunkHeader->ChunkSize * SparseHeader->BlockSize;
       break;
     default:
       UnicodeSPrint (


### PR DESCRIPTION
After noticing filesystem corruption on disk images after they
had been flashed to a board, regardless of kernel, I dug in and
found the fastboot sparse file handling was seeing overflows
of the Offset value.

Initially this was confusing as the Offset value is a UINTN,
so should be 64bits.

However, when flashing large images, fastboot will break the
sparse image up into separate segments.

After the first segment is sent, it prefixes the second segment
with a DONTCARE chunk (which skips writing to the disk and moves
Offset forward).  Unfortunately, the ChunkSize is defined as
a 32bit count of BlockSize (usually 4k) blocks.

So when the Offset in a previous segment grows beyond 32bits,
the following segment is prefixed with a DONTCARE chunk where
the ChunkSize*BlockSize should be equal to the preivous Offset
value.

Unfortunately, the calculations were done such that it
multiplied two UINT32 values without casting to a UINTN first,
resulting in the multiplicaiton overflowing and losing the high
bits.

This resulted in data being incorrectly written over the lower
32bit range of the partition.

Thus, this patch fixes the issue by casting the ChunkSize to
a UINTN before doing the multiplication and avoiding the
overflow

NOTE: This also needs to go upstream!

Signed-off-by: John Stultz <john.stultz@linaro.org>